### PR TITLE
New Feature: Making includePath available as part of local variables

### DIFF
--- a/tasks/includereplacemore.js
+++ b/tasks/includereplacemore.js
@@ -185,6 +185,8 @@ module.exports = function(grunt) {
 				if (localVars.docroot === undefined) {
 					localVars.docroot = docroot ? docroot + '/' : '';
 				}
+				
+				localVars.includePath = includePath;
 
 				grunt.log.debug('Including', includePath);
 				grunt.log.debug('Locals', localVars);


### PR DESCRIPTION
Making includePath available as part of local variables. This will help keeping tracking of location of code for developers new to codebase.
